### PR TITLE
[functionapp] Allow KuduLite to build squash fs image

### DIFF
--- a/kudu/Dockerfile
+++ b/kudu/Dockerfile
@@ -7,8 +7,10 @@ RUN apt-get update \
   && apt-get install -y openssh-client --no-install-recommends \
   && apt-get install -y vim tree --no-install-recommends \
   && apt-get install -y tcptraceroute \
+# Install Squashfs tools for KuduLite build
+  && apt-get install -y squashfs-tools \
   && wget -O /usr/bin/tcpping http://www.vdberg.org/~richard/tcpping \
-  && chmod 755 /usr/bin/tcpping 
+  && chmod 755 /usr/bin/tcpping
 
 # Enable SSH for Kudu Console
 RUN apt-get install -y ssh \
@@ -16,10 +18,10 @@ RUN apt-get install -y ssh \
    && sed -i '/^#PermitRootLogin* /s/^#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
    && sed -i '/^#PrintLastLog* /s/^#PrintLastLog yes/PrintLastLog no/' /etc/ssh/sshd_config \
    && chmod -R 0644 /etc/update-motd.d/ \
-   && echo "root:Docker!" | chpasswd 
+   && echo "root:Docker!" | chpasswd
 
 # SQL Server gem support
-RUN apt-get install -y unixodbc-dev freetds-dev freetds-bin 
+RUN apt-get install -y unixodbc-dev freetds-dev freetds-bin
 
 COPY webssh.zip ssh /tmp/
 
@@ -39,7 +41,7 @@ RUN mkdir -p /opt/Kudu/local \
   && chown root:root /usr/bin/ssh \
   && chmod 755 /usr/bin/ssh \
   && chmod -R 777 /home \
-  && rm -rf /tmp/* 
+  && rm -rf /tmp/*
 
 ENV DOTNET_RUNNING_IN_CONTAINER=true
 
@@ -49,7 +51,7 @@ ENV DOTNET_USE_POLLING_FILE_WATCHER=true
 # Skip extraction of XML docs - generally not useful within an image/container - helps performance
 ENV NUGET_XMLDOC_MODE=skip
 
-RUN dotnet tool install -g dotnet-aspnet-codegenerator 
+RUN dotnet tool install -g dotnet-aspnet-codegenerator
 ENV PATH=$PATH:/root/.dotnet/tools
 
 RUN cd /opt/dotnet && unlink lts && ln -s 2.2 /opt/dotnet/lts
@@ -74,7 +76,7 @@ RUN benv node=9 npm=6 npm install -g kudusync
 RUN benv node=9 npm=6 npm install pm2@latest -g
 
 RUN ln -s /opt/nodejs/9/lib/node_modules/npm/bin/npm-cli.js /usr/bin/npm-cli.js
-ENV PATH=$PATH:/opt/nodejs/9/bin 
+ENV PATH=$PATH:/opt/nodejs/9/bin
 
 EXPOSE 8181
 


### PR DESCRIPTION
### Background
We want to allow KuduLite to generate **.squashfs** package when running the build.
A squashfs file can **be mount directly without extraction**. This lifts the performance and reduce the function load time, especially when a user package has mountains of small files (such as /node_modules in node, /site-packages in python).

### Reference
Function host mount squashfs
https://github.com/Azure/azure-functions-host/pull/4523

@ankitkumarr @JennyLawrance @ahmelsayed