### PR TITLE
Update base image to mcr.microsoft.com/oryx/build:20200114.13

### DIFF
--- a/kudu/Dockerfile
+++ b/kudu/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oryx/build:20191216.3 as main
+FROM mcr.microsoft.com/oryx/build:20200114.13 as main
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Failed to build kudulite image from current mcr.microsoft.com/oryx/build:20191216.3.
After discussing with Gabriel Castro, he suggested using the latest version of oryx 20200114.13. 

https://github.com/Azure/azure-functions-docker/blob/master/kudulite/Dockerfile#L1